### PR TITLE
Dates

### DIFF
--- a/flicks/base/helpers.py
+++ b/flicks/base/helpers.py
@@ -1,0 +1,31 @@
+from django.utils.translation import get_language
+
+from babel.core import Locale, UnknownLocaleError
+from babel.dates import format_date
+from babel.numbers import format_number
+from jingo import register
+
+
+def _babel_locale():
+    """Return the current locale in Babel's format."""
+    try:
+        return Locale.parse(get_language(), sep='-')
+    except UnknownLocaleError:
+        # Default to en-US
+        return Locale('en', 'US')
+
+
+@register.filter
+def babel_date(date, format='long'):
+    """Format a date properly for the current locale. Format can be one of
+    'short', 'medium', 'long', or 'full'.
+    """
+    locale = _babel_locale()
+    return format_date(date, format, locale)
+
+
+@register.filter
+def babel_number(number):
+    """Format a number properly for the current locale."""
+    locale = _babel_locale()
+    return format_number(number, locale)

--- a/flicks/base/templates/shared/macros.html
+++ b/flicks/base/templates/shared/macros.html
@@ -20,10 +20,10 @@
       </p>
       <p class="video-info">
         {# TODO: Add video upload date and view count. #}
-        <span class="date"></span>
+        <span class="date">{{ video.created|babel_date }}</span>
         <span class="views">
           {# L10n: Refers to the number of views a video received. For example, 300 views. #}
-          {% trans view_count=300 %}
+          {% trans view_count=30000|babel_number %}
             {{ view_count }} view
             {% pluralize %}
             {{ view_count }} views

--- a/flicks/base/tests/test_helpers.py
+++ b/flicks/base/tests/test_helpers.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from nose.tools import eq_
+
+from flicks.base.helpers import babel_date, babel_number
+from flicks.base.tests import TestCase
+
+
+class TestHelpers(TestCase):
+    def test_babel_date(self):
+        date = datetime(2011, 9, 23)
+        with self.activate('en-US'):
+            eq_(babel_date(date, 'short'), '9/23/11')
+            eq_(babel_date(date, 'medium'), 'Sep 23, 2011')
+
+        with self.activate('fr'):
+            eq_(babel_date(date, 'short'), '23/09/11')
+            eq_(babel_date(date, 'medium'), '23 sept. 2011')
+
+    def test_babel_number(self):
+        number = 1000000
+        with self.activate('en-US'):
+            eq_(babel_number(number), u'1,000,000')
+
+        with self.activate('fr'):
+            # \xa0 is a non-breaking space
+            eq_(babel_number(number), u'1\xa0000\xa0000')

--- a/flicks/videos/migrations/0006_auto__add_field_video_created.py
+++ b/flicks/videos/migrations/0006_auto__add_field_video_created.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Video.created'
+        db.add_column('videos_video', 'created',
+                      self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=datetime.datetime(2012, 2, 13, 16, 7, 25, 195649), blank=True),
+                      keep_default=False)
+
+    def backwards(self, orm):
+        # Deleting field 'Video.created'
+        db.delete_column('videos_video', 'created')
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'videos.video': {
+            'Meta': {'object_name': 'Video'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'shortlink': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'unsent'", 'max_length': '10'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'upload_url': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'votes': ('django.db.models.fields.BigIntegerField', [], {'default': '0'})
+        }
+    }
+
+    complete_apps = ['videos']

--- a/flicks/videos/models.py
+++ b/flicks/videos/models.py
@@ -51,6 +51,7 @@ class Video(models.Model, SearchMixin):
     region = models.CharField(max_length=50, blank=False,
                               choices=REGION_CHOICES,
                               verbose_name=_lazy(u'Region'))
+    created = models.DateTimeField(auto_now_add=True)
 
     upload_url = models.URLField(verify_exists=False, blank=False, default='',
                                  verbose_name=_lazy(u'Video URL'))

--- a/flicks/videos/templates/videos/details.html
+++ b/flicks/videos/templates/videos/details.html
@@ -21,5 +21,6 @@
         {{ _('Upvote') }}
       </button>
       <div id="vote-count" data-votes="{{ video.votes }}">{{ video.votes }}</div>
+      <div id="video-date">{{ video.created|babel_date }}</div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Adds a `created` date field to videos, and displays it in the appropriate parts of the site.

Note that we shouldn't merge this pull request until we get confirmation from chelsea as to how she wants the dates to look in the site. Also, if babel doesn't support a date, it will default to en-US. Here's a short breakdown of how dates look:

<table>
<tr><th>Format</th><th>en-US</th><th>fr</th><th>es</th></tr>
<tr><td><code>short</code></td>
<td>2/13/12</td>
<td>13/02/12</td>
<td>13/02/12</td>
</tr>
<tr><td><code>medium</code></td>
<td>Feb 13, 2012</td>
<td>13 févr. 2012</td>
<td>13/02/2012</td>
</tr>
<tr><td><code>long</code></td>
<td>February 13, 2012</td>
<td>13 février 2012</td>
<td>13 de febrero de 2012</td>
</tr>
<tr><td><code>full</code></td>
<td>Monday, February 13, 2012</td>
<td>lundi 13 février 2012</td>
<td>lunes 13 de febrero de 2012</td>
</tr>
</table>
