### PR TITLE
Fix details page for users without a profile.

### DIFF
--- a/flicks/users/tests/test_views.py
+++ b/flicks/users/tests/test_views.py
@@ -80,3 +80,17 @@ class EditProfileTests(TestCase):
         self._post(bio='1234', full_name='bob', agreement='on')
         profile = UserProfile.objects.get(pk=user.pk)
         eq_(profile.bio, '1234')
+
+
+class DetailsTests(TestCase):
+    def _get(self, user_id):
+        with self.activate('en-US'):
+            response = self.client.get(reverse('flicks.users.details',
+                                               kwargs={'user_id': user_id}))
+        return response
+
+    def test_no_profile_404(self):
+        """If the requested user has no profile, return a 404."""
+        user = self.build_user(salt='no.profile', profile=False)
+        response = self._get(user.id)
+        eq_(response.status_code, 404)

--- a/flicks/users/views.py
+++ b/flicks/users/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_POST
@@ -12,7 +13,7 @@ from flicks.base.util import get_object_or_none, redirect
 from flicks.users.forms import UserProfileCreateForm, UserProfileEditForm
 from flicks.users.models import UserProfile
 from flicks.videos.forms import SearchForm
-from flicks.videos.models import User, Video
+from flicks.videos.models import Video
 
 
 def details(request, user_id=None):
@@ -23,6 +24,7 @@ def details(request, user_id=None):
     else:
         user = get_object_or_404(User, id=user_id)
         page_type = 'secondary user-details'
+    profile = get_object_or_404(UserProfile, user=user)
 
     show_pagination = False
 
@@ -56,7 +58,7 @@ def details(request, user_id=None):
              page_type=page_type,
              search_form=search_form,
              user=user,
-             profile=user.userprofile)
+             profile=profile)
 
     return render(request, 'users/details.html', d)
 


### PR DESCRIPTION
User details page returns a 404 if the requested user does not have a profile.
