### PR TITLE
Add view 404

### DIFF
--- a/flicks/videos/tests/test_views.py
+++ b/flicks/videos/tests/test_views.py
@@ -167,6 +167,11 @@ class AjaxAddViewTests(TestCase):
         response = self._post(None)
         eq_(response.status_code, 404)
 
+    def test_invalid_video_id(self):
+        """If video_id isn't an integer, return a 404."""
+        response = self._post('asdf')
+        eq_(response.status_code, 404)
+
     def test_no_video(self):
         """If there is no video with the given ID, return a 404."""
         response = self._post(9999999)

--- a/flicks/videos/views.py
+++ b/flicks/videos/views.py
@@ -83,7 +83,11 @@ def ajax_add_view(request):
     if video_id is None:
         raise Http404
 
-    viewcount = add_view(video_id)
+    try:
+        viewcount = add_view(video_id)
+    except ValueError:
+        raise Http404  # video_id is not an integer
+
     if viewcount is None:
         raise Http404
 


### PR DESCRIPTION
Fixes 500 caused by passing a non-integer video_id to ajax_add_view.
