### PR TITLE
Twitter url fix

### DIFF
--- a/flicks/videos/templates/videos/details.html
+++ b/flicks/videos/templates/videos/details.html
@@ -35,7 +35,9 @@
            title="{{ _('Upvote') }}">{{ video.votes }}</a>
       </div>
       <div id="share-container">
-        <button class="share" data-tweet-text="{{ tweet_text|e }}">Share!</button>
+        <button class="share"
+                data-tweet-text="{{ tweet_text|e }}"
+                data-video-share-link="{{ video.bitly_link }}">Share!</button>
         <div class="share-links">
           <div class="bitly-link">
             <input type="text" value="{{ video.bitly_link }}">

--- a/flicks/videos/views.py
+++ b/flicks/videos/views.py
@@ -67,7 +67,7 @@ def details(request, video_id=None):
     video = get_object_or_404(Video, pk=video_id, state='complete')
     viewcount = cached_viewcount(video_id)
     tweet_text = TWEET_TEXT % {'video_title': video.title[0:90],
-                               'link': video.bitly_link}
+                               'link': ''}  # URL is now included via JS
 
     d = dict(video=video,
              viewcount=viewcount,

--- a/media/js/share.js
+++ b/media/js/share.js
@@ -93,7 +93,8 @@ $.fn.showShare.twitter = function(options) {
     var settings = $.extend({
         count: 'vertical',
         lang: locale,
-        text: ''
+        text: '',
+        url: window.location
     }, ('twitter' in options ? options.twitter : {}));
 
     var output =
@@ -101,7 +102,8 @@ $.fn.showShare.twitter = function(options) {
             + 'class="twitter-share-button" '
             + 'data-count="' + settings.count + '" '
             + 'data-lang="' + settings.lang + '" '
-            + 'data-text="' + settings.text + '"></a>';
+            + 'data-text="' + settings.text + '" '
+            + 'data-url="' + settings.url + '"></a>';
 
     return {
         script: 'https://platform.twitter.com/widgets.js',
@@ -111,9 +113,11 @@ $.fn.showShare.twitter = function(options) {
 
 // Flicks-specific init code.
 $('body').on('click', '.share', function() {
-    $(this).next('.share-links').showShare(['facebook', 'twitter'], {
+    var share = $(this);
+    share.next('.share-links').showShare(['facebook', 'twitter'], {
         facebook: {appId: '198137183603911'},
-        twitter: {text: $(this).data('tweet-text')}
+        twitter: {text: share.data('tweet-text'),
+                  url: share.data('video-share-link')}
     });
 });
 


### PR DESCRIPTION
Twitter auto-appends the current URL unless you pass it explicitly. Since we included the shortlink in the message, this resulted in two links within the tweet.
