### PR TITLE
Check urls

### DIFF
--- a/flicks/settings/base.py
+++ b/flicks/settings/base.py
@@ -195,3 +195,8 @@ CSP_FRAME_SRC = ('http://s.vid.ly',
                  'https://platform.twitter.com',
                  'https://www.facebook.com',)
 CSP_OPTIONS = ('eval-script',)
+
+# Blacklist of unacceptable content-types for video URLs
+INVALID_VIDEO_CONTENT_TYPES = [
+    'text/'
+]

--- a/flicks/videos/tests/test_views.py
+++ b/flicks/videos/tests/test_views.py
@@ -1,6 +1,4 @@
 import socket
-from contextlib import nested
-from functools import partial
 
 from django.conf import settings
 from django.core import mail
@@ -10,6 +8,7 @@ from mock import patch
 from nose.tools import eq_, ok_
 
 from flicks.base.tests import TestCache, TestCase
+from flicks.videos.forms import UploadForm
 from flicks.videos.models import Video
 from flicks.videos.tasks import send_video_to_vidly
 from flicks.videos.tests import build_video
@@ -18,7 +17,9 @@ from flicks.videos.util import cached_viewcount
 
 @patch.object(send_video_to_vidly, 'delay')
 class UploadTests(TestCase):
-    def _post(self, **kwargs):
+    @patch.object(UploadForm, 'clean_upload_url')
+    def _post(self, clean_upload_url, **kwargs):
+        clean_upload_url.return_value = kwargs.get('url', 'http://test.com')
         """Execute upload view with kwargs as POST arguments."""
         args = {'title': 'Test', 'upload_url': 'http://test.com',
                 'category': 'thirty_spot', 'region': 'america',

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -189,7 +189,6 @@ body.form .form-wrapper, ul.errorlist, .content-wrapper .agreement {
     clear: both;
     display: block;
     margin: 0 auto;
-    width: 600px;
 }
 
 div.gravatar-content {
@@ -197,7 +196,9 @@ div.gravatar-content {
 }
 
 .content-wrapper ul.errorlist {
-    text-align: center;
+    color: #FF8383;
+    list-style-type: none;
+    margin-left: 230px;
 }
 
 div.field.error input, div.field.error select {
@@ -579,6 +580,10 @@ html[lang="tr"] #header {
         overflow-x: hidden;
     }
 
+    .content-wrapper ul.errorlist {
+        margin-left: 0px;
+    }
+
     .errorlist li {
         margin-left: 20px;
         text-align: left;
@@ -735,6 +740,10 @@ html[lang="tr"] #header {
         height: 136px;
     }
 
+    .content-wrapper ul.errorlist {
+        margin-left: 0px;
+    }
+
     .errorlist li {
         margin-left: 20px;
         text-align: left;
@@ -775,7 +784,7 @@ html[lang="tr"] #header {
         width: 100%;
     }
 
-    
+
     .home .video-blob {
         background-image: url('../img/home-black-bg-mobile.png');
     }


### PR DESCRIPTION
Checks URLs using a HEAD request during video submission, and notifies the user if their URL causes an error, either because of being inaccessible, or because of not being an actual video file (our most common case is users sending us a youtube link, which we cover by checking for a text/html content type.
