### PR TITLE
Fix bug with control characters in memcache keys.

### DIFF
--- a/flicks/videos/tests/test_views.py
+++ b/flicks/videos/tests/test_views.py
@@ -173,6 +173,11 @@ class AjaxAddViewTests(TestCase):
         response = self._post('asdf')
         eq_(response.status_code, 404)
 
+        # Test with control characters (bug 737564)
+        # Test cache will only raise a warning on this.
+        response = self._post(u"51 OR X='ss")
+        eq_(response.status_code, 404)
+
     def test_no_video(self):
         """If there is no video with the given ID, return a 404."""
         response = self._post(9999999)

--- a/flicks/videos/views.py
+++ b/flicks/videos/views.py
@@ -92,7 +92,7 @@ def ajax_add_view(request):
         raise Http404
 
     try:
-        viewcount = add_view(video_id)
+        viewcount = add_view(int(video_id))
 
         # Increment graphite stats
         statsd.incr('video_views')  # Total view count


### PR DESCRIPTION
Moves the integer check for `video_id` in `ajax_view_add` to occur before sending the id to memcached. Adds a test check for this as well.
