### PR TITLE
Fix views

### DIFF
--- a/flicks/base/tests/__init__.py
+++ b/flicks/base/tests/__init__.py
@@ -86,3 +86,6 @@ class TestCache(object):
     def incr(self, id):
         self.store[id] += 1
         return self.store[id]
+
+    def clear(self):
+        self.store = {}

--- a/flicks/settings/test.py
+++ b/flicks/settings/test.py
@@ -4,3 +4,9 @@ SITE_URL = 'http://test.com'
 
 VIDLY_USER_ID = '1234'
 VIDLY_USER_KEY = 'asdf'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}

--- a/flicks/videos/cron.py
+++ b/flicks/videos/cron.py
@@ -1,9 +1,13 @@
 import commonware.log
 import cronjobs
 
-from flicks.videos.models import Video
+from django.core.cache import cache
+
 from celery.task.sets import TaskSet
 from celeryutils import chunked
+
+from flicks.videos.models import Video
+from flicks.videos.util import VIEWS_KEY
 
 log = commonware.log.getLogger('m.cron')
 
@@ -14,6 +18,16 @@ def reindex_videos():
 
     ids = (Video.objects.values_list('id', flat=True))
 
-    ts = [tasks.index_objects.subtask(args=[Video, chunk]) for 
+    ts = [tasks.index_objects.subtask(args=[Video, chunk]) for
           chunk in chunked(sorted(list(ids)), 150)]
     TaskSet(ts).apply_async()
+
+
+@cronjobs.register
+def persist_viewcounts():
+    """Check the cache for stored view counts and write them to the DB."""
+    ids = (Video.objects.values_list('id', flat=True))
+    for video_id in ids:
+        viewcount = cache.get(VIEWS_KEY % video_id)
+        if viewcount is not None:
+            Video.objects.filter(id=video_id).update(views=viewcount)

--- a/flicks/videos/tests/test_cron.py
+++ b/flicks/videos/tests/test_cron.py
@@ -1,0 +1,37 @@
+from mock import patch
+from nose.tools import eq_
+
+from flicks.base.tests import TestCache, TestCase
+from flicks.videos.cron import persist_viewcounts
+from flicks.videos.models import Video
+from flicks.videos.tests import build_video
+from flicks.videos.util import VIEWS_KEY
+
+cache = TestCache()
+
+
+@patch('flicks.videos.cron.cache', cache)
+class PersistViewCountsTest(TestCase):
+    def setUp(self):
+        self.user = self.build_user()
+        cache.clear()
+
+    def test_no_videos(self):
+        """Test that the cron doesn't fail with no videos."""
+        Video.objects.all().delete()
+        persist_viewcounts()
+
+    def test_viewcount_updated(self):
+        """Test that videos with viewcounts in the cache are updated."""
+        with build_video(self.user, views=10) as video:
+            cache.set(VIEWS_KEY % video.id, 14)
+            eq_(Video.objects.get(id=video.id).views, 10)
+            persist_viewcounts()
+            eq_(Video.objects.get(id=video.id).views, 14)
+
+    def test_viewcount_unmodified(self):
+        """Test that videos without viewcounts in the cache are not updated."""
+        with build_video(self.user, views=10) as video:
+            eq_(Video.objects.get(id=video.id).views, 10)
+            persist_viewcounts()
+            eq_(Video.objects.get(id=video.id).views, 10)

--- a/flicks/videos/tests/test_util.py
+++ b/flicks/videos/tests/test_util.py
@@ -38,7 +38,7 @@ class AddViewTests(TestCase):
         based on the view count.
         """
         # Test each pair of (viewcount, # of view per save)
-        for viewcount, per_save in [(0, 1), (10, 5), (100, 25), (1000, 100)]:
+        for viewcount, per_save in [(0, 1), (100, 10)]:
             with build_video(self.user, views=viewcount) as video:
                 # Add per_save - 1 views and ensure each time that the DB
                 # hasn't been written to.

--- a/flicks/videos/util.py
+++ b/flicks/videos/util.py
@@ -27,10 +27,8 @@ def add_view(video_id):
     key = VIEWS_KEY % video_id
     viewcount = cache.incr(key)
     save_viewcount = (
-        (viewcount < 10) or
-        (viewcount < 100 and viewcount % 5 == 0) or
-        (viewcount < 1000 and viewcount % 25 == 0) or
-        (viewcount > 1000 and viewcount % 100 == 0)
+        (viewcount <= 100) or
+        (viewcount > 100 and viewcount % 10 == 0)
     )
 
     if save_viewcount:


### PR DESCRIPTION
Changes viewcounts to be saved to the DB every view until 100 views,
and then every 10 views after that. Also adds a cron management
command that loops through all current videos and saves them to
the DB if they have a viewcount stored in the DB.

fix bug 740638
