### PR TITLE
Add event list

### DIFF
--- a/flicks/base/templates/home.html
+++ b/flicks/base/templates/home.html
@@ -88,7 +88,7 @@
         </ol>
       </div>
       <div class="right-col promo">
-        {% include 'promos/%s.html' % ['edward_norton', 'youth', 'panavision']|random %}
+        {% include 'promos/%s.html' % ['edward_norton', 'youth', 'panavision', 'events']|random %}
       </div>
     </div>
   </div>

--- a/flicks/base/templates/partners.html
+++ b/flicks/base/templates/partners.html
@@ -54,5 +54,47 @@
            target="_blank">Adobe</a>
       </li>
     </ul>
+
+    <h1 id="events">{{ _('Events') }}</h1>
+
+    <h2>
+      {% trans href='http://www.bafici.gov.ar/home10/web/en/index.html' %}
+        April 19, 2012 &mdash; <a href="{{ href }}">Buenos Aires International
+        Independent Film Festival</a>
+      {% endtrans %}
+    </h2>
+    <p>
+      {% trans %}
+        A Mozilla event featuring a screening of a few early Firefox
+        Flicks entries from Latin America.
+      {% endtrans %}
+    </p>
+
+    <h2>
+      {% trans href='http://fest08.sffs.org/' %}
+        April 25, 2012 &mdash; <a href="{{ href }}">San Francisco International
+        Film Festival</a>
+      {% endtrans %}
+    </h2>
+    <p>
+      {% trans %}
+        A Mozilla event featuring a screening of a few early Firefox
+        Flicks entries from North America.
+      {% endtrans %}
+    </p>
+
+    <h2>{{ _('May 1, 2012 &mdash; Firefox Flicks Submissions Closed') }}</h2>
+
+    <h2>
+      {% trans href='http://www.festival-cannes.com/' %}
+        May 17, 2012 &mdash; <a href="{{ href }}">Cannes International Film Festival</a>
+      {% endtrans %}
+    </h2>
+    <p>
+      {% trans %}
+        Wrap Party for Firefox Flicks honoring regional winners and the
+        winner of the Panavision prize package.
+      {% endtrans %}
+    </p>
   </div>
 {% endblock %}

--- a/flicks/base/templates/promos/events.html
+++ b/flicks/base/templates/promos/events.html
@@ -1,0 +1,6 @@
+<h2>{{ _('Firefox Flicks Events') }}</h2>
+<p>
+  {% trans link='%s#%s' % (url('flicks.base.partners'), 'events') %}
+    Check out the listing of Firefox Flicks events <a href="{{ link }}">around the world</a>.
+  {% endtrans %}
+</p>

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1160,7 +1160,7 @@ body.home #header a.logo {
     width: 263px;
 }
 
-.content-wrapper p a, .content-wrapper li a {
+.content-wrapper p a, .content-wrapper li a, .content-wrapper h2 a {
     color: #398bc8;
     text-decoration: none;
 }


### PR DESCRIPTION
Adds a list of significant events to the Partners page and a front-page promo to link to it.
