### PR TITLE
Pagination search

### DIFF
--- a/flicks/base/templates/shared/macros.html
+++ b/flicks/base/templates/shared/macros.html
@@ -73,7 +73,8 @@
         {% if page == items.number %}
           <span>{{ page }}</span>
         {% else %}
-          <a href="{{ url|urlparams(page=page, limit=limit) }}">{{ page }}</a>
+          <a href="{{ url|urlparams(page=page, limit=limit, category=request.GET.get('category'),
+                   region=request.GET.get('region'), search=request.GET.get('search')) }}">{{ page }}</a>
         {% endif %}
       {% endfor %}
     </div>

--- a/flicks/videos/templates/videos/recent.html
+++ b/flicks/videos/templates/videos/recent.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from 'shared/macros.html' import paginate, display_search_form, search_results, video_item %}
+{% from 'shared/macros.html' import paginate, display_search_form, search_results, video_item with context %}
 
 {% if search %}
   {% set title=_('Video Search Results') %}


### PR DESCRIPTION
Fixes an issue where search parameters are lost when following page links at the bottom of the search by adding the parameters to the pagination macro. If a parameter is not specified, it does not show up in the page link.
