### PR TITLE
Fix for quotes in video title attributes

### DIFF
--- a/flicks/base/templates/home.html
+++ b/flicks/base/templates/home.html
@@ -125,8 +125,8 @@
 
       <ul class="entry-list">
         <li class="entry">
-          {# l10n: This is "watch" meaning to view a video, used in link labels #}
-          <a href="https://vimeo.com/57627458" class="video-play" title="{% trans title='Falling in Love with Firefox' %}Watch "{{ title }}"{% endtrans %}" data-vimeo-id="57627458">
+          {# l10n: This is "watch" meaning to view a video, used in link labels. #}
+          <a href="https://vimeo.com/57627458" class="video-play" title='{% trans title='Falling in Love with Firefox' %}Watch "{{ title }}"{% endtrans %}' data-vimeo-id="57627458">
             <img src="{{ MEDIA_URL }}img/home/vidthumb-falling.jpg" alt="" class="thumbnail">
             <hgroup>
               <h2>Falling in Love with Firefox</h2>
@@ -138,7 +138,7 @@
           </a>
         </li>
         <li class="entry">
-          <a href="https://vimeo.com/57627456" class="video-play" title="{% trans title='Be a Hero' %}Watch "{{ title }}"{% endtrans %}" data-vimeo-id="57627456">
+          <a href="https://vimeo.com/57627456" class="video-play" title='{% trans title='Be a Hero' %}Watch "{{ title }}"{% endtrans %}' data-vimeo-id="57627456">
             <img src="{{ MEDIA_URL }}img/home/vidthumb-hero.jpg" alt="" class="thumbnail">
             <hgroup>
               <h2>Be a Hero</h2>
@@ -150,7 +150,7 @@
           </a>
         </li>
         <li class="entry">
-          <a href="https://vimeo.com/57627464" class="video-play" title="{% trans title='Squares' %}Watch "{{ title }}"{% endtrans %}" data-vimeo-id="57627464">
+          <a href="https://vimeo.com/57627464" class="video-play" title='{% trans title='Squares' %}Watch "{{ title }}"{% endtrans %}' data-vimeo-id="57627464">
             <img src="{{ MEDIA_URL }}img/home/vidthumb-squares.jpg" alt="" class="thumbnail">
             <hgroup>
               <h2>Squares</h2>
@@ -162,7 +162,7 @@
           </a>
         </li>
         <li class="entry">
-          <a href="https://vimeo.com/57627933" class="video-play" title="{% trans title='Where the Weird Things Are Not' %}Watch "{{ title }}"{% endtrans %}" data-vimeo-id="57627933">
+          <a href="https://vimeo.com/57627933" class="video-play" title='{% trans title='Where the Weird Things Are Not' %}Watch "{{ title }}"{% endtrans %}' data-vimeo-id="57627933">
             <img src="{{ MEDIA_URL }}img/home/vidthumb-weird.jpg" alt="" class="thumbnail">
             <hgroup>
               <h2>Where the Weird Things Are Not</h2>
@@ -174,7 +174,7 @@
           </a>
         </li>
         <li class="entry">
-          <a href="https://vimeo.com/57627455" class="video-play" title="{% trans title='Paranoid' %}Watch "{{ title }}"{% endtrans %}" data-vimeo-id="57627455">
+          <a href="https://vimeo.com/57627455" class="video-play" title='{% trans title='Paranoid' %}Watch "{{ title }}"{% endtrans %}' data-vimeo-id="57627455">
             <img src="{{ MEDIA_URL }}img/home/vidthumb-paranoid.jpg" alt="" class="thumbnail">
             <hgroup>
               <h2>Paranoid</h2>
@@ -186,7 +186,7 @@
           </a>
         </li>
         <li class="entry">
-          <a href="https://vimeo.com/57627454" class="video-play" title="{% trans title='Fenwick & Candy' %}Watch "{{ title }}"{% endtrans %}" data-vimeo-id="57627454">
+          <a href="https://vimeo.com/57627454" class="video-play" title='{% trans title='Fenwick & Candy' %}Watch "{{ title }}"{% endtrans %}' data-vimeo-id="57627454">
             <img src="{{ MEDIA_URL }}img/home/vidthumb-fenwick.jpg" alt="" class="thumbnail">
             <hgroup>
               <h2>Fenwick & Candy</h2>


### PR DESCRIPTION
Enclosing the attribute value in single quotes allows double quotes in the value. This is just a short term hack to avoid string changes. We can get away with this because none of the video titles in question contain an apostrophe.

In the next revision we should instead encode those quotes as entities, or else solve the problems with verbatim and unicode characters.
