### PR TITLE
Link to localized creative briefs when available

### DIFF
--- a/flicks/base/templates/faq.html
+++ b/flicks/base/templates/faq.html
@@ -37,7 +37,7 @@
     </p>
 
     <p>
-    {% trans link_brief='http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_en-US.pdf' %}
+    {% trans link_brief=link_brief %}
       With that in mind, the 2013 Firefox Flicks theme is "Get Mobilized."
       That's where you come in: help us inspire people to get mobilized for
       individual and collective progress. <a href="{{ link_brief }}">Read the creative brief</a>.
@@ -46,7 +46,7 @@
 
     <h2 id="q2">{{ _('Where can I find out more about this year\'s theme and requirements?') }}</h2>
     <p>
-    {% trans link_brief='http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_en-US.pdf' %}
+    {% trans link_brief=link_brief %}
       Everything you need to know about creating a flick for the contest
       can be found in the filmmakers' <a href="{{ link_brief }}">creative brief</a>.
     {% endtrans %}

--- a/flicks/base/templates/home.html
+++ b/flicks/base/templates/home.html
@@ -56,7 +56,7 @@
           </li>
           <li>
             <h3>{{ _('Start thinking about your flick') }}</h3>
-            <p><a href="http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_en-US.pdf" hreflang="en-US" class="go" rel="external">{{ _('Read the creative brief') }}</a></p>
+            <p><a href="{{ link_brief }}" class="go" rel="external">{{ _('Read the creative brief') }}</a></p>
           </li>
         </ul>
       </div>
@@ -90,7 +90,7 @@
           and get people excited about the future of the Web on mobile.
         {% endtrans %}
         </p>
-        <p><a href="http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_en-US.pdf" hreflang="en-US" class="go" rel="external">{{ _('Read the creative brief to get started') }}</a></p>
+        <p><a href="{{ link_brief }}" class="go" rel="external">{{ _('Read the creative brief to get started') }}</a></p>
       </div>
 
       <div class="actions">

--- a/flicks/base/views.py
+++ b/flicks/base/views.py
@@ -18,10 +18,21 @@ LINK_PDWIKI = {
     'zh-TW': 'https://zh.wikipedia.org/wiki/%E5%85%AC%E6%9C%89%E9%A2%86%E5%9F%9F ',
 }
 
+LINK_BRIEF = {
+    'en-US': 'http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_en-US.pdf',
+    'de': 'http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_de.pdf',
+    'es': 'http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_es-ES.pdf',
+    'nl': 'http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_nl.pdf',
+    'pl': 'http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_pl.pdf',
+    'sl': 'http://static.mozilla.com/firefoxflicks/pdf/Filmmakers_Creative_Brief_sl.pdf',
+}
+
 
 def home(request):
     """Home page."""
-    return render(request, 'home.html')
+    return render(request, 'home.html', {
+        'link_brief': LINK_BRIEF.get(request.locale, LINK_BRIEF['en-US'])
+    })
 
 
 def creative(request):
@@ -55,7 +66,8 @@ def partners(request):
 def faq(request):
     """FAQ page."""
     return render(request, 'faq.html', {
-        'link_pdwiki': LINK_PDWIKI.get(request.locale, LINK_PDWIKI['en-US'])
+        'link_pdwiki': LINK_PDWIKI.get(request.locale, LINK_PDWIKI['en-US']),
+        'link_brief': LINK_BRIEF.get(request.locale, LINK_BRIEF['en-US'])
     })
 
 


### PR DESCRIPTION
Defaults to English for locales for which we don't have a translated PDF.
