### PR TITLE
Temporarily redirect invalid locales to the homepage.

### DIFF
--- a/flicks/base/urls.py
+++ b/flicks/base/urls.py
@@ -1,6 +1,12 @@
 from django.conf.urls.defaults import patterns, url
 
 from flicks.base import views
+from flicks.base.util import redirect
+
+
+def redirect_to(name):
+    return lambda request: redirect(name)
+
 
 urlpatterns = patterns('',
     url(r'^/?$', views.home, name='flicks.base.home'),
@@ -8,4 +14,8 @@ urlpatterns = patterns('',
     url(r'^rules/?$', views.rules, name='flicks.base.rules'),
     url(r'^judges/?$', views.judges, name='flicks.base.judges'),
     url(r'^strings/?$', views.strings, name='flicks.base.strings'),
+
+    # Temporarily redirect all invalid locales to the home page.
+    url(r'^(?:\w{2,3}(?:-\w{2}(?:-mac)?)?)?/',
+        redirect_to('flicks.base.home')),
 )


### PR DESCRIPTION
Funfactory's LocaleURLMiddleware will tack en-US onto any URL without an
active locale, such as /fr -> /en-US/fr/. This causes 404s when it tries
to match on the url /fr.

This is a temporary fix that redirects any path that starts with a
locale-like string to the homepage. This should catch any redirects with
locales in the path and just push users towards the homepage. We'll 
remove this once the locales we want are back in.
