### PR TITLE
Fix bug 849913: Fix unicode issues with video titles and descriptions.

### DIFF
--- a/flicks/settings/base.py
+++ b/flicks/settings/base.py
@@ -29,7 +29,6 @@ INSTALLED_APPS = list(INSTALLED_APPS) + [
 
     'django.contrib.admin',
 
-    'csp',
     'django_browserid',
     'django_statsd',
     'jingo_minify',
@@ -131,6 +130,8 @@ CSP_FRAME_SRC = ("'self'",
                  'https://*.vimeo.com',
                  'https://*.vimeocdn.com',
                  'https://login.persona.org',)
+CSP_DEFAULT_SRC = ("'self'",
+                   'https://*.vimeo.com',)
 
 # Activate statsd patches to time database and cache hits.
 STATSD_PATCHES = [

--- a/flicks/videos/models.py
+++ b/flicks/videos/models.py
@@ -113,7 +113,7 @@ class Video2013(models.Model, CachingMixin):
     def __unicode__(self):
         profile = self.user.profile
         name = profile.display_name if profile else self.user.email
-        return '`{0}` - {1}'.format(self.title, name)
+        return u'`{0}` - {1}'.format(self.title, name)
 
 
 @receiver(models.signals.post_delete, sender=Video2013)

--- a/flicks/videos/tasks.py
+++ b/flicks/videos/tasks.py
@@ -24,7 +24,7 @@ def process_video(video_id):
         vimeo.set_title(video.vimeo_id, video.title)
 
         # Set description to title + author + description.
-        description = '{title} by {author}\n\n{description}'.format(
+        description = u'{title} by {author}\n\n{description}'.format(
             title=video.title, author=video.user.profile.display_name,
             description=video.description)
         vimeo.set_description(video.vimeo_id, description)
@@ -47,7 +47,7 @@ def process_video(video_id):
         moderators = User.objects.filter(Q(groups__permissions=perm) |
                                          Q(user_permissions=perm)).distinct()
 
-        subject = ('[flicks-moderation] `{0}` is ready for review'
+        subject = (u'[flicks-moderation] `{0}` is ready for review'
                    .format(video.title))
         message = render_to_string('videos/2013/moderation_email.html',
                                    {'video': video})

--- a/flicks/videos/tests/test_vimeo.py
+++ b/flicks/videos/tests/test_vimeo.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import requests
 from mock import ANY, Mock, patch
 from nose.tools import eq_, ok_
@@ -129,3 +130,27 @@ class TestVimeo(TestCase):
             vimeo._video_request('method', 'POST', video_id='id',
                                  error_msg='{video_id} {code} {msg} {expl}')
         eq_(cm.exception.args, ('id tcode tmsg texpl',))
+
+    @patch('flicks.videos.vimeo._video_request')
+    def test_set_title_unicode(self, _video_request):
+        """
+        Titles passed to set_title should be encoded in ASCII, with non-ASCII
+        being encoded using HTML/XML entities.
+        """
+        vimeo.set_title('1234', u'Basket ball à')
+        _video_request.assert_called_with('vimeo.videos.setTitle', 'POST',
+                                          video_id='1234',
+                                          title='Basket ball &#224;',
+                                          error_msg=ANY)
+
+    @patch('flicks.videos.vimeo._video_request')
+    def test_set_description_unicode(self, _video_request):
+        """
+        Descriptions passed to set_description should be encoded in ASCII, with
+        non-ASCII being encoded using HTML/XML entities.
+        """
+        vimeo.set_description('1234', u'Basket ball à')
+        _video_request.assert_called_with('vimeo.videos.setDescription', 'POST',
+                                          video_id='1234',
+                                          description='Basket ball &#224;',
+                                          error_msg=ANY)

--- a/flicks/videos/urls.py
+++ b/flicks/videos/urls.py
@@ -11,6 +11,8 @@ urlpatterns = patterns('',
     url(r'^upload/$', views.upload, name='flicks.videos.upload'),
     url(r'^upload/complete/$', views.upload_complete,
         name='flicks.videos.upload_complete'),
+    url(r'^upload/error/$', views.upload_error,
+        name='flicks.videos.upload_error'),
 
     # 2012 Archive pages
     url(r'^(?P<video_id>\d+)$', views.details_2012,

--- a/flicks/videos/vimeo.py
+++ b/flicks/videos/vimeo.py
@@ -118,10 +118,11 @@ def verify_chunks(ticket_id, expected_size):
 @vimeo_task
 def complete_upload(ticket_id, filename):
     """Mark an upload as complete and submit it for processing."""
+    msg = ('Error completing upload for ticket `{ticket_id}`: <{code} {msg}> '
+           '{expl}')
     response = _ticket_request('vimeo.videos.upload.complete', 'POST',
-        ticket_id=ticket_id, filename=filename,
-        error_msg='Error completing upload for ticket `{ticket_id}`: '
-                  '<{code} {msg}> {expl}')
+                               ticket_id=ticket_id, filename=filename,
+                               error_msg=msg)
     return response['ticket']
 
 
@@ -129,7 +130,7 @@ def complete_upload(ticket_id, filename):
 def set_title(video_id, title):
     """Set the title of a video."""
     _video_request('vimeo.videos.setTitle', 'POST', video_id=video_id,
-                   title=title,
+                   title=title.encode('ascii', 'xmlcharrefreplace'),
                    error_msg='Error setting title for video {video_id}: '
                              '<{code} {msg}> {expl}')
 
@@ -138,7 +139,7 @@ def set_title(video_id, title):
 def set_description(video_id, description):
     """Set the description of a video."""
     _video_request('vimeo.videos.setDescription', 'POST', video_id=video_id,
-                   description=description,
+                   description=description.encode('ascii', 'xmlcharrefreplace'),
                    error_msg='Error setting description for video {video_id}: '
                              '<{code} {msg}> {expl}')
 


### PR DESCRIPTION
Vimeo can't accept encoded UTF-8 in API requests, but it can accept
HTML-entity-encoded text, so we encode titles and descriptions as ASCII
and convert any unicode characters to HTML/XML entities.

Other fixes:
- Remove django-csp from the app list as the migrations for csp break my
  local MySQL database and we aren't using reporting anyway.
- Add /video/upload/error/ URL that accidentally got removed; the upload
  error code in the JS uses it.
