### PR TITLE
Fix bug 861274 - video pillarboxing

### DIFF
--- a/flicks/videos/static/css/videos.css
+++ b/flicks/videos/static/css/videos.css
@@ -1,6 +1,6 @@
 .video {
     background: #000;
-    height: 337px;
+    height: 529px;
     position: relative;
 }
 
@@ -91,6 +91,10 @@
 /* Tablet Layout: 760px */
 @media only screen and (min-width: 760px) and (max-width: 1000px) {
 
+  .video {
+    height: 405px;
+  }
+
   #trailers {
     width: auto;
     float: none;
@@ -114,6 +118,11 @@
 
 /* Mobile Layout: 320px */
 @media only screen and (max-width: 760px) {
+
+  .video {
+    height: 259px;
+  }
+
   .video-details h1 {
     font-size: 28px;
     margin: 0 0 15px;


### PR DESCRIPTION
Adjust the video height to maintain 16:9 aspect ratio. Some other aspect ratios will still get boxed, but this should cover most entries.
