### PR TITLE
added empty alt-attribute

### DIFF
--- a/flicks/base/templates/carousel/blogpost_baficiwinner.html
+++ b/flicks/base/templates/carousel/blogpost_baficiwinner.html
@@ -4,18 +4,18 @@
     <h2>{{ _('Now playing: April 3 winners') }}</h2>
     <p>
       {% trans %}
-      Help us congratulate our first group of Early Entry Award 
-      winners who automatically qualify for the Grand Prize.        
+      Help us congratulate our first group of Early Entry Award
+      winners who automatically qualify for the Grand Prize.
       {% endtrans %}
     </p>
     <p class="act">
       <a href="http://tmblr.co/ZIO4nviRWAJT" class="go" rel="external">{{ _('Read the blog post') }}</a>
       <span>* {{ _('English only') }}</span>
     </p>
-    
+
     <a href="https://vimeo.com/63166600" class="video-play" data-vimeo-id="63166600">
-      <img src="{{ static('img/home/vidthumb-promo-hubba.jpg') }}" class="thumbnail">
+      <img src="{{ static('img/home/vidthumb-promo-hubba.jpg') }}" alt="" class="thumbnail">
       <div>{{ _('Watch the winning flick') }}</div>
-    </a>    
+    </a>
   </div>
 </div>


### PR DESCRIPTION
Sort of refs https://github.com/mozilla/firefox-flicks/pull/195#discussion_r3902571

the alt-attribute is required on `<img>` if it's not present then screenreaders and other AT will guess it's content and maybe announce the src-attribute.

Therefor a empty alt-attribute is to recommend here.
