### PR TITLE
Fix Bug 854725: Removed 2 day rotation

### DIFF
--- a/flicks/base/carousel.py
+++ b/flicks/base/carousel.py
@@ -10,8 +10,7 @@ slide_schedule = (
     ScheduleItem(date(2013, 5, 1), date(2013, 5, 7), ['blogpost_shootingpeople.html', 'blogpost_baficiwinner.html', 'blogpost_makeyourflickawinner.html']),
     ScheduleItem(date(2013, 5, 8), date(2013, 5, 17), ['may29_earlyentry.html', 'blogpost_shootingpeople.html', 'blogpost_makeyourflickawinner.html']),
     ScheduleItem(date(2013, 5, 18), date(2013, 5, 29), ['may29_earlyentry.html', 'blogpost_getmobilized.html', 'blogpost_makeyourflickawinner.html']),
-    ScheduleItem(date(2013, 5, 30), date(2013, 5, 31), ['blogpost_winbig.html', 'blogpost_getmobilized.html', 'blogpost_makeyourflickawinner.html']),
-    ScheduleItem(date(2013, 6, 1), date(2013, 6, 11), ['july3_earlyentry.html', 'blogpost_getmobilized.html', 'july31_earlyentry.html']),
+    ScheduleItem(date(2013, 5, 30), date(2013, 6, 11), ['blogpost_winbig.html', 'blogpost_getmobilized.html', 'blogpost_makeyourflickawinner.html']),
 )
 
 


### PR DESCRIPTION
Removed 2 day rotation per comment in bug 854725. This change would need to be pushed prior to 5/30.
