### PR TITLE
Bug 886500: Add autocomplete dropdown.

### DIFF
--- a/flicks/base/http.py
+++ b/flicks/base/http.py
@@ -1,0 +1,21 @@
+import json
+
+from django.http import HttpResponse
+
+
+class JSONResponse(HttpResponse):
+    """
+    HttpResponse that takes in a list or dict and outputs JSON for the response
+    body.
+    """
+    def __init__(self, data, status=200):
+        """
+        :param data:
+            List or dict to serialize to JSON in the response body.
+
+        :param status:
+            HTTP status code to use for this response. Defaults to 200.
+        """
+        data_json = json.dumps(data)
+        super(JSONResponse, self).__init__(
+            data_json, mimetype='application/json', status=status)

--- a/flicks/base/static/js/libs/jquery.typing-0.2.0.js
+++ b/flicks/base/static/js/libs/jquery.typing-0.2.0.js
@@ -1,0 +1,82 @@
+// jQuery-typing
+//
+// Version: 0.2.0
+// Website: http://narf.pl/jquery-typing/
+// License: public domain <http://unlicense.org/>
+// Author:  Maciej Konieczny <hello@narf.pl>
+
+(function ($) {
+
+    //--------------------
+    //  jQuery extension
+    //--------------------
+
+    $.fn.typing = function (options) {
+        return this.each(function (i, elem) {
+            listenToTyping(elem, options);
+        });
+    };
+
+
+    //-------------------
+    //  actual function
+    //-------------------
+
+    function listenToTyping(elem, options) {
+        // override default settings
+        var settings = $.extend({
+            start: null,
+            stop: null,
+            delay: 400
+        }, options);
+
+        // create other function-scope variables
+        var $elem = $(elem),
+            typing = false,
+            delayedCallback;
+
+        // start typing
+        function startTyping(event) {
+            if (!typing) {
+                // set flag and run callback
+                typing = true;
+                if (settings.start) {
+                    settings.start(event, $elem);
+                }
+            }
+        }
+
+        // stop typing
+        function stopTyping(event, delay) {
+            if (typing) {
+                // discard previous delayed callback and create new one
+                clearTimeout(delayedCallback);
+                delayedCallback = setTimeout(function () {
+                    // set flag and run callback
+                    typing = false;
+                    if (settings.stop) {
+                        settings.stop(event, $elem);
+                    }
+                }, delay >= 0 ? delay : settings.delay);
+            }
+        }
+
+        // listen to regular keypresses
+        $elem.keypress(startTyping);
+
+        // listen to backspace and delete presses
+        $elem.keydown(function (event) {
+            if (event.keyCode === 8 || event.keyCode === 46) {
+                startTyping(event);
+            }
+        });
+
+        // listen to keyups
+        $elem.keyup(stopTyping);
+
+        // listen to blurs
+        $elem.blur(function (event) {
+            stopTyping(event, 0);
+        });
+    }
+})(jQuery);

--- a/flicks/base/tests/test_http.py
+++ b/flicks/base/tests/test_http.py
@@ -1,0 +1,22 @@
+import json
+
+from nose.tools import eq_
+
+from flicks.base.http import JSONResponse
+from flicks.base.tests import TestCase
+
+
+class JSONResponseTests(TestCase):
+    def test_basic(self):
+        response = JSONResponse({'blah': 'foo', 'bar': 7})
+        eq_(json.loads(response.content), {'blah': 'foo', 'bar': 7})
+        eq_(response.status_code, 200)
+
+        response = JSONResponse(['baz', {'biff': False}])
+        eq_(response.content, '["baz", {"biff": false}]')
+        eq_(response.status_code, 200)
+
+    def test_status(self):
+        response = JSONResponse({'blah': 'foo', 'bar': 7}, status=404)
+        eq_(json.loads(response.content), {'blah': 'foo', 'bar': 7})
+        eq_(response.status_code, 404)

--- a/flicks/settings/base.py
+++ b/flicks/settings/base.py
@@ -200,6 +200,7 @@ MINIFY_BUNDLES = {
     'js': {
         'jquery': (
             'js/libs/jquery-1.7.1.min.js',
+            'js/libs/jquery.typing-0.2.0.js',
         ),
         'google_analytics': (
             'js/ga.js',
@@ -213,6 +214,7 @@ MINIFY_BUNDLES = {
         'flicks_js': (
             'js/init.js',
             'js/vote.js',
+            'js/search.js',
         ),
         'home_js': (
             'js/libs/jquery.waypoints.min.js',

--- a/flicks/videos/forms.py
+++ b/flicks/videos/forms.py
@@ -1,9 +1,11 @@
 from django import forms
+from django.core.exceptions import ValidationError
 
 from tower import ugettext_lazy as _lazy
 
 from flicks.base.regions import region_names
 from flicks.videos.models import Video
+from flicks.videos.search import search_videos
 
 
 class VideoForm(forms.ModelForm):
@@ -19,14 +21,50 @@ class VideoForm(forms.ModelForm):
         }
 
 
-class VideoSearchForm(forms.Form):
-    REGION_CHOICES = [('', _lazy('All Regions'))] + region_names.items()
+FIELD_FILTERS = {
+    'title': ('title',),
+    'description': ('description',),
+    'author': ('user__userprofile__full_name',)
+}
 
-    query = forms.CharField(required=False)
-    region = forms.TypedChoiceField(
-        required=False, choices=REGION_CHOICES, coerce=int,
-        empty_value=None)
-    sort = forms.ChoiceField(required=False, choices=(
+
+class VideoSearchForm(forms.Form):
+    """Form for the search feature on the video listing page."""
+    FIELD_CHOICES = [(value, '') for value in FIELD_FILTERS.keys()]
+    REGION_CHOICES = [('', _lazy('All Regions'))] + region_names.items()
+    SORT_CHOICES = (
         ('', _lazy('by Title')),
         ('popular', _lazy('by Popularity')),
-    ))
+    )
+
+    query = forms.CharField(
+        required=False,
+        widget=forms.TextInput(attrs={'autocomplete': 'off'}))
+    region = forms.TypedChoiceField(
+        required=False,
+        choices=REGION_CHOICES,
+        coerce=int,
+        empty_value=None)
+    sort = forms.ChoiceField(
+        required=False,
+        choices=SORT_CHOICES)
+    field = forms.ChoiceField(
+        required=False,
+        choices=FIELD_CHOICES,
+        widget=forms.HiddenInput)
+
+    def perform_search(self):
+        """
+        Perform a search using the parameters bound to this form.
+
+        :throws ValidationError: If the form doesn't pass validation.
+        """
+        if not self.is_valid():
+            raise ValidationError('Form must be valid to perform search.')
+
+        return search_videos(
+            query=self.cleaned_data['query'],
+            fields=FIELD_FILTERS.get(self.cleaned_data['field'], None),
+            region=self.cleaned_data['region'],
+            sort=self.cleaned_data['sort'],
+        )

--- a/flicks/videos/search.py
+++ b/flicks/videos/search.py
@@ -6,7 +6,10 @@ from flicks.base import regions
 from flicks.videos.models import Video
 
 
-def search_videos(query=None, region=None, sort=None):
+DEFAULT_QUERY_FIELDS = ('title', 'description', 'user__userprofile__full_name')
+
+
+def search_videos(query=None, fields=None, region=None, sort=None):
     """
     Retrieve a sorted list of videos, optionally filtered by a text search
     query and region.
@@ -15,6 +18,10 @@ def search_videos(query=None, region=None, sort=None):
         Search query. The video title and description are searched, as well as
         the full name of the user who created the video. Limited to a simple
         "icontains" filter.
+
+    :param fields:
+        Fields to apply search query to. Defaults to video title, description,
+        and user's full name.
 
     :param region:
         If present, filters videos to only those found in the specified region.
@@ -29,12 +36,11 @@ def search_videos(query=None, region=None, sort=None):
     # Text search
     if query:
         filters = []
+        fields = fields or DEFAULT_QUERY_FIELDS
         for term in query.split(None, 6):  # Limit to 6 to guard against abuse.
-            filters.extend([
-                Q(title__icontains=term),
-                Q(description__icontains=term),
-                Q(user__userprofile__full_name__icontains=term)
-            ])
+            for field in fields:
+                kwarg = '{0}__icontains'.format(field)
+                filters.append(Q(**{kwarg: term}))
         qs = qs.filter(reduce(operator.or_, filters))  # Mash 'em all together!
 
     # Filter by region
@@ -45,8 +51,28 @@ def search_videos(query=None, region=None, sort=None):
 
     # Sorting
     if sort == 'popular':
-        qs = qs.annotate(vote_count=Count('voters')).order_by('-vote_count')
+        # NOTE: Naming this count `vote_count` triggers a bug in Django since
+        # there's a property named that on the model.
+        qs = qs.annotate(votecount=Count('voters')).order_by('-votecount')
     else:
         qs = qs.order_by('title')  # Default sort is by title.
 
     return qs
+
+
+def autocomplete_suggestion(query, field):
+    """
+    Perform a search on a specific field and return the value of that field on
+    the first result as a suggested autocompletion value.
+
+    :param query:
+        Search query that we are attempting to autocomplete.
+
+    :param field:
+        Field that we are attempting autocompletion for.
+    """
+    try:
+        result = search_videos(query=query, fields=(field,)).values(field)[0]
+        return result[field]
+    except IndexError:
+        return None

--- a/flicks/videos/static/css/videos.css
+++ b/flicks/videos/static/css/videos.css
@@ -223,6 +223,14 @@
     background-image: linear-gradient(150deg, #c0a665 0%, #ffe8d0 35%, #9f7d38 100%);
 }
 
+.suggestions {
+  display: none;
+}
+
+.suggestions .selected {
+  background: #999;
+}
+
 /* Tablet Layout: 760px */
 @media only screen and (min-width: 760px) and (max-width: 1000px) {
 
@@ -248,11 +256,11 @@
     float: left;
     margin: 0 15px 1.5em;
   }
-  
+
   .winners-page .section-intro {
       width: auto;
   }
-  
+
   .period {
       margin: 0 -20px 2em 0;
       width: auto;
@@ -300,7 +308,7 @@
   .winners-page .entry-list {
     width: auto;
   }
-  
+
   .period {
     margin: 0 0 2em;
   }
@@ -337,15 +345,15 @@
   #trailers .entry:nth-child(2n+1) {
     clear: none;
   }
-  
+
   .period .entry-list {
     margin-left: -10px;
   }
-  
+
   .period .entry-list .entry {
       width: 190px;
   }
-  
+
   .period .entry-list .third-place {
     float: none;
     clear: both;

--- a/flicks/videos/static/js/search.js
+++ b/flicks/videos/static/js/search.js
@@ -1,0 +1,249 @@
+;(function($, flicks) {
+    'use strict';
+
+    var UP = 38;
+    var DOWN = 40;
+    var ENTER = 13;
+
+    $(function() {
+        // Hook up the search form manipulator and autocomplete widget.
+        var searchForm = new SearchForm($('#video-search'));
+        new AutoComplete(searchForm);
+    });
+
+    /**
+     * Displays an autocomplete dropdown on the search form when the user
+     * enters a search query.
+     */
+    function AutoComplete(form) {
+        this.form = form;
+        this.xhr = null;
+        this.lastQuery = null;
+        this.autocompleteSubmit = false;
+
+        this.bindEvents();
+    }
+
+    AutoComplete.prototype = {
+        bindEvents: function() {
+            var self = this;
+            this.form.onQueryTyping({
+                stop: function(e, $elem) {
+                    self.onStopTyping(e, $elem);
+                }
+            });
+            this.form.onQueryKeyDown(function(e) {
+                self.onKeyDown(e);
+            });
+
+            // Clicking a suggestion also triggers an autocomplete search.
+            this.form.onSuggestionClick(function(e) {
+                self.autocompleteSubmit = true;
+                self.form.setSelected($elem.data('field'));
+                self.form.submitSelected();
+            });
+
+            // Clear the field input if we are not performing an autocomplete
+            // search to avoid unintended field filtering.
+            this.form.onSubmit(function(e) {
+                if (!self.autocompleteSubmit) {
+                    self.form.clearField();
+                }
+            });
+
+            // If the query box loses focus, clear the selection.
+            this.form.onQueryBlur(function(e) {
+                self.form.clearSelected();
+            });
+        },
+
+        /**
+         * When the user stops typing, hide the autocomplete box and fetch new
+         * suggestions, displaying the autocomplete box again if any matches
+         * are found.
+         */
+        onStopTyping: function(e, $elem) {
+            var query = this.form.getQuery();
+            if (this.lastQuery && this.lastQuery === query) {
+                return; // Don't bother with repeats.
+            } else {
+                this.lastQuery = query;
+            }
+
+            // Hide the suggestions box and abort current autocompletion.
+            this.form.hideSuggestions();
+            this.form.clearSelected();
+            if (this.xhr) {
+                this.xhr.abort();
+            }
+
+            // If empty, clear the autocomplete box but do nothing else.
+            if (!query) {
+                return;
+            }
+
+            // Retrieve suggestions and fill the dropdown with them.
+            var self = this;
+            this.xhr = $.get(this.form.autoCompleteUrl, {query: query});
+            this.xhr.done(function(results) {
+                var titleFound = self.form.fillSuggestion(
+                    'title', results.by_title);
+                var descFound = self.form.fillSuggestion(
+                    'description', results.by_description);
+                var nameFound = self.form.fillSuggestion(
+                    'author', results.by_author);
+
+                // If at least one suggestion is found, show the dropdown.
+                if (titleFound || descFound || nameFound) {
+                    self.form.showSuggestions();
+                }
+            });
+        },
+
+        /**
+         * If the user presses up or down, scroll through the available
+         * suggestions. If they pressed enter and have selected one of the
+         * suggestions, perform a search on that suggestion.
+         */
+        onKeyDown: function(e) {
+            var isMoveKey = e.keyCode == UP || e.keyCode == DOWN;
+            if (isMoveKey && this.form.suggestionsAreVisible()) {
+                e.preventDefault();
+                this.form.moveSelected(e.keyCode);
+            } else if (e.keyCode == ENTER && this.form.hasSelected()) {
+                this.autocompleteSubmit = true;
+                this.form.submitSelected();
+            }
+        }
+    };
+
+    /**
+     * Handles DOM manipulation of the search form for the autocomplete widget.
+     */
+    function SearchForm($form) {
+        this.$form = $form;
+        this.$query = $form.find('input[name="query"]');
+        this.$field = $form.find('input[name="field"]');
+        this.$suggestions = $form.find('.suggestions');
+
+        this.autoCompleteUrl = this.$form.data('autocompleteUrl');
+
+        this._suggestions = {
+            title: this.$suggestions.find('.title'),
+            description: this.$suggestions.find('.description'),
+            author: this.$suggestions.find('.author')
+        };
+    }
+
+    SearchForm.prototype = {
+        // Event binding.
+        onQueryTyping: function(options) {
+            this.$query.typing(options);
+        },
+
+        onQueryKeyDown: function(handler) {
+            this.$query.keydown(handler);
+        },
+
+        onQueryBlur: function(handler) {
+            this.$query.blur(handler);
+        },
+
+        onSuggestionClick: function(handler) {
+            this.$suggestions.on('click', 'li:visible', handler);
+        },
+
+        onSubmit: function(handler) {
+            this.$form.submit(handler);
+        },
+
+        // Controlling the list of suggestions.
+
+        hideSuggestions: function() {
+            this.$suggestions.hide();
+        },
+
+        showSuggestions: function() {
+            this.$suggestions.show();
+        },
+
+        fillSuggestion: function(field, value) {
+            var $suggestion = this._suggestions[field];
+            if (!$suggestion) {
+                return false;
+            } else if (!value) {
+                $suggestion.hide();
+                return false;
+            } else if (value) {
+                $suggestion.show().find('span').text(value);
+                return true;
+            }
+        },
+
+        suggestionsAreVisible: function() {
+            return this.$suggestions.is(':visible');
+        },
+
+        // Manipulating the currently selected suggestion.
+
+        clearSelected: function() {
+            this.$suggestions.find('.selected').removeClass('selected');
+        },
+
+        hasSelected: function() {
+            return !!this.getSelected().length;
+        },
+
+        getSelected: function() {
+            return this.$suggestions.find('.selected');
+        },
+
+        moveSelected: function(direction) {
+            var $current = this.getSelected();
+            var $next = null;
+
+            if (direction == UP) {
+                $next = $current.prev(':visible');
+                if (!$next.length) {
+                    $next = this.$suggestions.find('li:visible').last();
+                }
+            } else {
+                $next = $current.next(':visible');
+                if (!$next.length) {
+                    $next = this.$suggestions.find('li:visible').first();
+                }
+            }
+
+            this.clearSelected();
+            $next.addClass('selected');
+        },
+
+        setSelected: function(field) {
+            var $suggestion = this._suggestions['$' + field];
+            if ($suggestion) {
+                this.clearSelected();
+                $suggestion.addClass('selected');
+            }
+        },
+
+        // Miscellaneous
+
+        clearField: function() {
+            this.$field.val('');
+        },
+
+        getQuery: function() {
+            return this.$query.val();
+        },
+
+
+        submitSelected: function() {
+            var $suggestion = this.getSelected();
+            if ($suggestion.length) {
+                this.$query.val($suggestion.find('span').text());
+                this.$field.val($suggestion.data('field'));
+                this.$form.submit();
+            }
+        }
+    };
+})(jQuery, flicks);

--- a/flicks/videos/templates/videos/2013/list.html
+++ b/flicks/videos/templates/videos/2013/list.html
@@ -28,9 +28,20 @@
     </div>
 
     {% if waffle.flag('r3') %}
-      <form>
+      <form id="video-search" data-autocomplete-url="{{ url('flicks.videos.autocomplete') }}">
         {{ form.as_ul() }}
         <button type="submit">Search</button>
+        <ul class="suggestions">
+          <li class="title" data-field="title">
+            Title: <span></span>
+          </li>
+          <li class="description" data-field="description">
+            Description: <span></span>
+          </li>
+          <li class="author" data-field="author">
+            Author Name: <span></span>
+          </li>
+        </ul>
       </form>
     {% endif %}
 
@@ -64,7 +75,8 @@
           {{ pagination(videos, url('flicks.videos.list'),
                         region=request.GET.get('region', None),
                         query=request.GET.get('query', None),
-                        sort=request.GET.get('sort', None)) }}
+                        sort=request.GET.get('sort', None),
+                        field=request.GET.get('field', None)) }}
         {% endif %}
       </div>
     {% endblock %}

--- a/flicks/videos/tests/test_forms.py
+++ b/flicks/videos/tests/test_forms.py
@@ -1,0 +1,50 @@
+from django.core.exceptions import ValidationError
+
+from mock import patch
+from nose.tools import assert_raises, eq_
+
+from flicks.base.regions import NORTH_AMERICA
+from flicks.base.tests import TestCase
+from flicks.videos.forms import FIELD_FILTERS, VideoSearchForm
+
+
+class VideoSearchFormTests(TestCase):
+    @patch('flicks.videos.forms.search_videos')
+    def test_valid_search(self, search_videos):
+        form = VideoSearchForm({
+            'query': 'asdf',
+            'field': 'title',
+            'region': NORTH_AMERICA,
+            'sort': 'popular'
+        })
+
+        eq_(form.perform_search(), search_videos.return_value)
+        search_videos.assert_called_with(
+            query='asdf',
+            fields=FIELD_FILTERS['title'],
+            region=NORTH_AMERICA,
+            sort='popular'
+        )
+
+    @patch('flicks.videos.forms.search_videos')
+    def test_empty_field_passes_none(self, search_videos):
+        """If the field isn't specified, pass None to the fields parameter."""
+        form = VideoSearchForm({
+            'query': 'asdf',
+            'region': NORTH_AMERICA,
+            'sort': 'popular'
+        })
+
+        eq_(form.perform_search(), search_videos.return_value)
+        search_videos.assert_called_with(query='asdf', fields=None,
+                                         region=NORTH_AMERICA, sort='popular')
+
+    def test_invalid_form(self):
+        """If the form fails validation, throw a ValidationError."""
+        form = VideoSearchForm({
+            'region': -5,
+            'sort': 'invalid'
+        })
+
+        with assert_raises(ValidationError):
+            form.perform_search()

--- a/flicks/videos/urls.py
+++ b/flicks/videos/urls.py
@@ -10,6 +10,10 @@ urlpatterns = patterns(
     url(r'^2013/(\d+)/$', views.video_detail, name='flicks.videos.detail'),
     url(r'^winners/?$', views.winners, name='flicks.videos.winners'),
 
+    # Search pages
+    url(r'^autocomplete/$', views.autocomplete,
+        name='flicks.videos.autocomplete'),
+
     # Upload pages
     url(r'^upload/$', views.upload, name='flicks.videos.upload'),
     url(r'^upload/complete/$', views.upload_complete,


### PR DESCRIPTION
Adds a JS-powered widget to the search page that shows suggested
completions for a user's search term. It's not super-smart; in the
background it performs the search and returns the first result found,
which isn't weighted by a score or anything, so it's mostly a shot in
the dark. But it's not terrible if you're searching for a semi-unique
string; the primary use-case here is people searching for videos by
their friends.

The design of the frontend bits are in one of craigcook's pull
requests, and I'll be integrating it later. The JavaScript is
functionally complete, although it will be modified to fit whatever
frontend craigcook came up with.

I decided to try a different approach to the JavaScript bits by
separating the widget logic with the DOM-handling code. It's a little
verbose in this case, but I'm actually quite happy with the result.
