### PR TITLE
Fix bug 904281: Add more ways to see stats about votes to the admin.

### DIFF
--- a/flicks/base/admin.py
+++ b/flicks/base/admin.py
@@ -6,6 +6,28 @@ from django.utils.html import escape
 from caching.base import CachingQuerySet
 
 
+class NumVotesFilter(admin.SimpleListFilter):
+    """Allows filtering on the `num_votes` attribute."""
+    title = 'number of votes'
+    parameter_name = 'num_votes'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('0', 'No votes'),
+            ('1', 'At least 1'),
+            ('5', 'At least 5'),
+            ('10', 'At least 10'),
+            ('20', '20 or more'),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == '0':
+            return queryset.filter(num_votes=0)
+        elif self.value():
+            minimum = int(self.value())
+            return queryset.filter(num_votes__gte=minimum)
+
+
 class BaseModelAdmin(admin.ModelAdmin):
     """
     Base class to use for ModalAdmins across the site.

--- a/flicks/users/admin.py
+++ b/flicks/users/admin.py
@@ -1,14 +1,24 @@
 from django.contrib.admin import site
 from django.contrib.auth import admin
 from django.contrib.auth.models import User
+from django.db import models
+
+from flicks.base.admin import NumVotesFilter
 
 
 class UserAdmin(admin.UserAdmin):
     """Configuration for the user admin pages."""
-    list_display = ['email', 'nickname', 'username', 'full_name', 'country',
+    list_display = ['email', 'nickname', 'num_votes', 'username', 'full_name', 'country',
                     'is_staff']
     search_fields = ['email', 'userprofile__nickname', 'username',
                      'userprofile__full_name', 'userprofile__nickname']
+    list_filter = [NumVotesFilter, 'is_staff']
+
+    def queryset(self, request):
+        """Add num_votes field to queryset."""
+        qs = super(UserAdmin, self).queryset(request)
+        qs = qs.annotate(num_votes=models.Count('voted_videos'))
+        return qs
 
     def full_name(self, user):
         return user.profile.full_name
@@ -18,5 +28,10 @@ class UserAdmin(admin.UserAdmin):
 
     def country(self, user):
         return user.profile.country
+
+    def num_votes(self, user):
+        # Use method on the admin so we can sort by this field.
+        return user.vote_count
+    num_votes.admin_order_field = 'num_votes'
 site.unregister(User)
 site.register(User, UserAdmin)

--- a/flicks/videos/migrations/0026_auto__add_field_vote_created.py
+++ b/flicks/videos/migrations/0026_auto__add_field_vote_created.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Vote.created'
+        db.add_column('videos_vote', 'created',
+                      self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Vote.created'
+        db.delete_column('videos_vote', 'created')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'videos.award': {
+            'Meta': {'object_name': 'Award'},
+            'award_type': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'preview': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'video': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['videos.Video2012']", 'null': 'True', 'blank': 'True'})
+        },
+        'videos.video2012': {
+            'Meta': {'object_name': 'Video2012'},
+            'bitly_link_db': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'judge_mark': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'shortlink': ('django.db.models.fields.CharField', [], {'max_length': '32', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'unsent'", 'max_length': '10'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'upload_url': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200'}),
+            'user_country': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'user_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100'}),
+            'views': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'votes': ('django.db.models.fields.BigIntegerField', [], {'default': '0'})
+        },
+        'videos.video2013': {
+            'Meta': {'object_name': 'Video2013'},
+            'approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'processed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'random_ordering': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'user_notified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'vimeo_id': ('django.db.models.fields.IntegerField', [], {}),
+            'voters': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'voted_videos'", 'symmetrical': 'False', 'through': "orm['videos.Vote']", 'to': "orm['auth.User']"})
+        },
+        'videos.vote': {
+            'Meta': {'unique_together': "(('user', 'video'),)", 'object_name': 'Vote'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'video': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['videos.Video2013']"})
+        }
+    }
+
+    complete_apps = ['videos']

--- a/flicks/videos/models.py
+++ b/flicks/videos/models.py
@@ -148,6 +148,8 @@ class Vote(models.Model, CachingMixin):
     user = models.ForeignKey(User)
     video = models.ForeignKey(Video2013)
 
+    created = models.DateTimeField(default=datetime.now)
+
     objects = CachingManager()
 
     class Meta:


### PR DESCRIPTION
Adds a few niceties to the admin interface to make it easier to find
information about how many votes there are, who has voted, what they
have voted on, etc.

There's no tests because admin stuff is in general hard to test and
the set of users for this stuff is small and limited to trusted 
individuals. The only testable thing here is the admin filter, but it's
trivial and doesn't handle any edge cases.
