### PR TITLE
Bug 904278: Fix GA vote and login tracking.

### DIFF
--- a/flicks/users/views.py
+++ b/flicks/users/views.py
@@ -51,6 +51,9 @@ class Verify(django_browserid.views.Verify):
             video = Video.objects.get(id=video_id)
             Vote.objects.get_or_create(user=self.request.user, video=video)
             del self.request.session['vote_video']
+
+            # Set cookie so the JavaScript knows they successfully voted.
+            response.set_cookie('just_voted', '1', max_age=3600, httponly=False)
         except (Video.DoesNotExist, ValueError):
             # Avoid retrying on an invalid video.
             del self.request.session['vote_video']


### PR DESCRIPTION
Fixes JavaScript to only send the vote event to GA after the vote has been saved. Also moves the login attempt event outside of the getAssertion callback because we're tracking attempts, not just successful attempts.
