### PR TITLE
Add filter to vote admin that uses a select box for display.

### DIFF
--- a/flicks/videos/admin.py
+++ b/flicks/videos/admin.py
@@ -6,6 +6,10 @@ from flicks.videos import models
 from flicks.videos.tasks import process_video
 
 
+class SelectRelatedFieldListFilter(admin.filters.RelatedFieldListFilter):
+    template = 'admin/filters_select.html'
+
+
 class Video2013Admin(BaseModelAdmin):
     list_display = ['title', 'user_full_name', 'user_email', 'num_votes', 'created',
                     'vimeo_id', 'filename', 'processed', 'approved']
@@ -77,7 +81,7 @@ class Video2013Admin(BaseModelAdmin):
 
 class VoteAdmin(BaseModelAdmin):
     list_display = ['user_nickname', 'user_email', 'video', 'created']
-    list_filter = ['created']
+    list_filter = ['created', ('video', SelectRelatedFieldListFilter)]
     search_fields = ['user__userprofile__full_name', 'user__userprofile__nickname', 'user__email',
                      'video__title']
 

--- a/flicks/videos/templates/admin/filters_select.html
+++ b/flicks/videos/templates/admin/filters_select.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+
+<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
+<select onchange="document.location = this.options[this.selectedIndex].value;" style="width: 150px; margin: 5px">
+  {% for choice in choices %}
+    <option{% if choice.selected %} selected="selected"{% endif %} value="{{ choice.query_string|iriencode }}">
+      {{ choice.display }}
+    </option>
+  {% endfor %}
+</select>


### PR DESCRIPTION
Admin filters [have a template property](https://github.com/django/django/blob/1.4.5/django/contrib/admin/filters.py#L21) that the [admin change list template](https://github.com/django/django/blob/1.4.5/django/contrib/admin/templates/admin/change_list.html#L81) uses to [lookup and render](https://github.com/django/django/blob/1.4.5/django/contrib/admin/templatetags/admin_list.py#L365) the list of filter options. [The default filter template](https://github.com/django/django/blob/1.4.5/django/contrib/admin/templates/admin/filter.html) uses an unordered list of links to display the available filter options, but a select box is better for things like related fields that may have a TON of choices.

This PR adds a filter that uses a select box and is subsequently used to filter votes by the video they are assigned to in the admin interface.
